### PR TITLE
Add basic frontend templates and testing config

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,13 +22,14 @@ from app.routes.profile.account import profile_bp
 from app.routes.dashboard.home import dashboard_bp
 from app.routes.subscription.plans import subscription_bp
 from app.routes.admin import admin_bp
+from app.routes.main.home import main_bp
 from app.routes.api.v1.user_api import user_api_bp
 from app.routes.api.v1.subscription_api import subscription_api_bp
 
 # Determine project root (one level above app/)
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
-def create_app():
+def create_app(config_name: str | None = None):
     """
     Factory to create and configure the Flask application.
     """
@@ -53,10 +54,13 @@ def create_app():
     ])
 
     # ---------- Load configuration ----------
-    env = os.getenv("FLASK_ENV", "production").lower()
-    if env == "development":
+    config = (config_name or os.getenv("FLASK_ENV", "production")).lower()
+    if config == "development":
         app.config.from_object(DevelopmentConfig)
-    elif env == "production":
+    elif config == "testing":
+        from app.config.testing import TestingConfig
+        app.config.from_object(TestingConfig)
+    elif config == "production":
         app.config.from_object(ProductionConfig)
     else:
         app.config.from_object(BaseConfig)
@@ -84,7 +88,7 @@ def create_app():
         level=logging.INFO,
         format="[%(asctime)s] %(levelname)s in %(module)s: %(message)s"
     )
-    logging.info(f"Starting app in '{env}' mode")
+    logging.info(f"Starting app in '{config}' mode")
     logging.info(f"DEBUG={app.config.get('DEBUG')}  DATABASE_URI={app.config.get('SQLALCHEMY_DATABASE_URI')}")
 
     # ---------- Initialize extensions ----------
@@ -103,7 +107,7 @@ def create_app():
 
     # ---------- Register blueprints ----------
     for bp in (
-        auth_bp, profile_bp, dashboard_bp,
+        main_bp, auth_bp, profile_bp, dashboard_bp,
         subscription_bp, admin_bp,
         user_api_bp, subscription_api_bp
     ):

--- a/app/config/testing.py
+++ b/app/config/testing.py
@@ -1,0 +1,6 @@
+from .base import BaseConfig
+
+class TestingConfig(BaseConfig):
+    TESTING = True
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
+    WTF_CSRF_ENABLED = False

--- a/app/forms/__init__.py
+++ b/app/forms/__init__.py
@@ -72,6 +72,10 @@ _auth_forms = [
 ]
 _register_forms(_auth_forms)
 
+# Backward compatibility alias
+RegistrationForm = RegisterForm
+__all__.append("RegistrationForm")
+
 
 # ─── Profile Forms ────────────────────────────────────────────────────────────
 _profile_forms = [

--- a/app/routes/main/__init__.py
+++ b/app/routes/main/__init__.py
@@ -1,0 +1,3 @@
+from .home import main_bp
+
+__all__ = ["main_bp"]

--- a/app/routes/main/home.py
+++ b/app/routes/main/home.py
@@ -1,0 +1,9 @@
+from flask import Blueprint
+from app.utils.decorators import safe_render
+
+main_bp = Blueprint("main", __name__)
+
+@main_bp.route("/home", methods=["GET"])
+def home():
+    """Render the public landing page."""
+    return safe_render("main/home.html")

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+  console.log('ISREAL.AI frontend initialized');
+});

--- a/frontend/main.scss
+++ b/frontend/main.scss
@@ -1,0 +1,11 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #0d1117;
+  color: #f0f6fc;
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  color: #58a6ff;
+}

--- a/frontend/modules/auth/login.html
+++ b/frontend/modules/auth/login.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <label for="email">Email</label>
+    {{ form.email(size=32) }}
+    <label for="password">Password</label>
+    {{ form.password(size=32) }}
+    <label>{{ form.remember_me() }} Remember me</label>
+    <button type="submit">Login</button>
+  </form>
+  <p>Need an account? <a href="{{ url_for('auth.register') }}">Sign up</a></p>
+</body>
+</html>

--- a/frontend/modules/auth/signup.html
+++ b/frontend/modules/auth/signup.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Sign Up</title>
+</head>
+<body>
+  <h1>Sign Up</h1>
+  <form method="post">
+    {{ form.hidden_tag() }}
+    <label for="name">Name</label>
+    {{ form.name(size=32) }}
+    <label for="email">Email</label>
+    {{ form.email(size=32) }}
+    <label for="password">Password</label>
+    {{ form.password(size=32) }}
+    <label for="confirm_password">Confirm Password</label>
+    {{ form.confirm_password(size=32) }}
+    <button type="submit">Register</button>
+  </form>
+  <p>Already registered? <a href="{{ url_for('auth.login') }}">Login</a></p>
+</body>
+</html>

--- a/frontend/modules/dashboard/index.html
+++ b/frontend/modules/dashboard/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Dashboard</title>
+</head>
+<body>
+  <h1>Dashboard</h1>
+  <p>Welcome {{ user.name if user else 'user' }}.</p>
+  <p><a href="{{ url_for('auth.logout') }}">Logout</a></p>
+</body>
+</html>

--- a/frontend/modules/errors/404.html
+++ b/frontend/modules/errors/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Page Not Found</title>
+</head>
+<body>
+  <h1>404 - Page Not Found</h1>
+  <p>The requested page could not be found.</p>
+  <p><a href="{{ url_for('main.home') }}">Back to home</a></p>
+</body>
+</html>

--- a/frontend/modules/errors/500.html
+++ b/frontend/modules/errors/500.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Server Error</title>
+</head>
+<body>
+  <h1>500 - Server Error</h1>
+  <p>An internal server error occurred.</p>
+  <p><a href="{{ url_for('main.home') }}">Back to home</a></p>
+</body>
+</html>

--- a/frontend/modules/main/home.html
+++ b/frontend/modules/main/home.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>ISREAL.AI Authentication</title>
+</head>
+<body>
+  <h1>Welcome to ISREAL.AI</h1>
+  <p>This service provides authentication for our applications.</p>
+  <p><a href="{{ url_for('auth.login') }}">Login</a> or <a href="{{ url_for('auth.register') }}">Sign Up</a></p>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ psycopg2-binary==2.9.5
 SQLAlchemy==1.4.42
 Werkzeug==2.2.2
 WTForms==3.0.1
+Flask-Migrate==3.1.0
+Flask-JWT-Extended==4.4.4
+Flask-Limiter==3.12


### PR DESCRIPTION
## Summary
- add main blueprint and public home page
- implement minimal login, signup, dashboard, and error templates
- wire index script, base styles, and testing configuration
- extend app factory for config selection and document dependencies

## Testing
- `PYTHONPATH=. pytest` *(fails: Unable to build URLs outside an active request and mapper configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897b5cbb2348320b006e26c7b0ef7bc